### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Or install it yourself as:
 
 ```
 <source>
+  @type specinfra_inventory
   time_span      300
   tag_prefix     example.prefix
   backend        exec

--- a/fluent-plugin-specinfra_inventory.gemspec
+++ b/fluent-plugin-specinfra_inventory.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fluentd"
+  spec.add_dependency "fluentd", [">= 0.14.0", "< 2"]
   spec.add_dependency "specinfra", ">= 2.17.1"
 
   spec.add_development_dependency "bundler", "~> 1.7"

--- a/spec/in_specinfra_inventory_spec.rb
+++ b/spec/in_specinfra_inventory_spec.rb
@@ -1,10 +1,11 @@
 require 'spec_helper'
+require 'fluent/test/driver/input'
 require 'fluent/plugin/in_specinfra_inventory'
 
-describe Fluent::SpecinfraInventoryInput do
+describe Fluent::Plugin::SpecinfraInventoryInput do
   before do
     Fluent::Test.setup
-    @d = Fluent::Test::InputTestDriver.new(Fluent::SpecinfraInventoryInput).configure(config)
+    @d = Fluent::Test::Driver::Input.new(Fluent::Plugin::SpecinfraInventoryInput).configure(config)
     @d.instance.inventory = {
       'cpu' => {
         'total' => "2",


### PR DESCRIPTION
I've tried to migrate to use v0.14 Input Plugin API.
This PR contains major update change.
Could you bump up minor/major version not patch level if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks,